### PR TITLE
Add atomic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # vendor/
 
 examples/send-atomic-group/Example_atomic_tx
+
+# Private info
+test/config.toml

--- a/account/http.go
+++ b/account/http.go
@@ -21,8 +21,8 @@ func GetAccountInfo(hezClient client.HermezClient, account string) (hezAccount A
 		err = fmt.Errorf("[Account][GetAccountInfo] Boot Coordinator is not set : %s", hezClient.BootCoordinatorURL)
 		return
 	}
-	account = formatHezAccountAddress(account)
-	url := "/v1/accounts?" + account
+	// account = formatHezAccountAddress(account)
+	url := "/v1/accounts?BJJ=" + account
 	// log.Printf("[Account][GetAccountInfo] URL %s", url)
 	req, err := hezClient.BootCoordinatorClient.New().Get(url).Request()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/dghubble/sling v1.3.0
 	github.com/ethereum/go-ethereum v1.10.4
-	github.com/hermeznetwork/hermez-node v1.5.0-rc2.0.20210713144540-6a0bb24d49e4
+	github.com/hermeznetwork/hermez-node v1.6.0-rc1.0.20210716151651-15bff406e54a
 	github.com/iden3/go-iden3-crypto v0.0.6-0.20210308142348-8f85683b2cef
 	github.com/miguelmota/go-ethereum-hdwallet v0.0.0-20210626002539-518b14aa39c0
 	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hermeznetwork/hermez-go-sdk
 go 1.16
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/dghubble/sling v1.3.0
 	github.com/ethereum/go-ethereum v1.10.4
 	github.com/hermeznetwork/hermez-node v1.5.0-rc2.0.20210713144540-6a0bb24d49e4

--- a/go.sum
+++ b/go.sum
@@ -406,6 +406,10 @@ github.com/hermeznetwork/hermez-go-sdk v0.1.1/go.mod h1:IJUcE8mSHTAX0aucz0CxNwat
 github.com/hermeznetwork/hermez-node v1.1.0/go.mod h1:cq4UzG6AqY+KTzgsIyU2/LggAYhUB/DHI7B+FGvg4nw=
 github.com/hermeznetwork/hermez-node v1.5.0-rc2.0.20210713144540-6a0bb24d49e4 h1:ilv+uUlB5YBDBrrBZ155zlsM/fdax+bZWmieqZeUtsA=
 github.com/hermeznetwork/hermez-node v1.5.0-rc2.0.20210713144540-6a0bb24d49e4/go.mod h1:k1/gPw04W4s2MPIxs4pF7ROd6EsWM0FZfZ1NBWVpVGw=
+github.com/hermeznetwork/hermez-node v1.6.0-rc1.0.20210716150545-cf4bf731560c h1:wOGGWz1mr6FdiR62YAduVPA9M0uuMNjeSSpeWbe5TSY=
+github.com/hermeznetwork/hermez-node v1.6.0-rc1.0.20210716150545-cf4bf731560c/go.mod h1:k1/gPw04W4s2MPIxs4pF7ROd6EsWM0FZfZ1NBWVpVGw=
+github.com/hermeznetwork/hermez-node v1.6.0-rc1.0.20210716151651-15bff406e54a h1:S7NJbOWG7n5jRvtpDXmhuzvg6qKE+un0plYC3HdFqCg=
+github.com/hermeznetwork/hermez-node v1.6.0-rc1.0.20210716151651-15bff406e54a/go.mod h1:k1/gPw04W4s2MPIxs4pF7ROd6EsWM0FZfZ1NBWVpVGw=
 github.com/hermeznetwork/tracerr v0.3.1-0.20210120162744-5da60b576169 h1:I7zgVVlOgf+26yrrKKY9UT+9f73qqlNBGX6C9MPXnk4=
 github.com/hermeznetwork/tracerr v0.3.1-0.20210120162744-5da60b576169/go.mod h1:nsWC1+tc4qUEbUGRv4DcPJJTjLsedlPajlFmpJoohK4=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+# Integration tests
+
+This tests are run against a deployed node using the Go SDK. It's assumed that the node is working well before the test starts.
+
+## Usage
+
+1. Before runing a test, read the requirements specified at the beginning of `<test name>/main.go`.
+2. Copy `test/config.example.toml` into `test/config.toml` and edit the values, making sure that the requirements are fulfilled.
+3. Run the test: `cd test && go run ./<test name>`

--- a/test/atomic/main.go
+++ b/test/atomic/main.go
@@ -1,0 +1,117 @@
+package main
+
+/*
+This integration test will perform atomic transactions.
+
+Config requirements:
+- Two EthPrivKeys that have HEZ accounts with funds on Goerli
+- HermezNodeURL operating on Goerli, should win the auction too, oterwise the test will run forever
+*/
+
+import (
+	"math/big"
+	"time"
+
+	integration "github.com/hermeznetwork/hermez-go-sdk/test"
+	"github.com/hermeznetwork/hermez-go-sdk/transaction"
+	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/log"
+)
+
+func main() {
+	// Load integration testing
+	it, err := integration.NewIntegrationTest()
+	if err != nil {
+		log.Error(err)
+		panic("Failed initializing integration testing framework")
+	}
+	if len(it.Wallets) < 2 {
+		panic("To run this test at least two wallets with HEZ deposited must be provided.")
+	}
+	// Test happy path
+	if err := caseHappyPath(it); err != nil {
+		log.Error(err)
+		panic("Failed testing case: happy path")
+	}
+	// Test reject and follow
+	if err := caseRejectAndFollow(it); err != nil {
+		log.Error(err)
+		panic("Failed testing case: reject and follow")
+	}
+}
+
+// caseHappyPath send a valid (nonce, balance, ...) atomic group of two linked txs
+func caseHappyPath(it integration.IntegrationTest) error {
+	log.Info("Start atomic test case: happy path")
+	log.Info("Sending atomic group of two linked txs")
+	// Define txs
+	tx1 := transaction.AtomicTxItem{
+		SenderBjjWallet:       it.Wallets[0],
+		RecipientAddress:      it.Wallets[1].HezEthAddress,
+		TokenSymbolToTransfer: "HEZ",
+		Amount:                big.NewInt(100000000000000000),
+		FeeRangeSelectedID:    126,
+		RqOffSet:              1, //+1
+	}
+
+	tx2 := transaction.AtomicTxItem{
+		SenderBjjWallet:       it.Wallets[1],
+		RecipientAddress:      it.Wallets[0].HezEthAddress,
+		TokenSymbolToTransfer: "HEZ",
+		Amount:                big.NewInt(100000000000000000),
+		FeeRangeSelectedID:    126,
+		RqOffSet:              7, //-1
+	}
+	txs := make([]transaction.AtomicTxItem, 2)
+	txs[0] = tx1
+	txs[1] = tx2
+
+	// create PoolL2Txs
+	atomicGroup := common.AtomicGroup{}
+	fullTxs, err := transaction.CreateFullTxs(it.Client, txs)
+	if err != nil {
+		return err
+	}
+	atomicGroup.Txs = fullTxs
+
+	// set AtomicGroupID
+	atomicGroup = transaction.SetAtomicGroupID(atomicGroup)
+
+	// Sign the txs
+	for i := range txs {
+		var txHash *big.Int
+		txHash, err = atomicGroup.Txs[i].HashToSign(uint16(5))
+		if err != nil {
+			return err
+		}
+		signature := txs[i].SenderBjjWallet.PrivateKey.SignPoseidon(txHash)
+		atomicGroup.Txs[i].Signature = signature.Compress()
+	}
+
+	// j, _ := json.Marshal(atomicGroup)
+	// panic(string(j))
+
+	// Post
+	var serverResponse string
+	serverResponse, err = transaction.SendAtomicTxsGroup(it.Client, atomicGroup)
+	if err != nil {
+		return err
+	}
+	log.Info("Txs sent successfuly: ", serverResponse)
+	log.Info("You can manually check the status of the txs at: <node URL>/1/atomic-pool/")
+	// Wait until txs are forged
+	log.Info("Entering a wait loop until txs are forged")
+	const timeBetweenChecks = 10 * time.Second
+	if err := integration.WaitUntilTxsAreForged(atomicGroup.Txs, timeBetweenChecks, it.Client); err != nil {
+		return err
+	}
+	log.Info("Atomic group has been forged")
+	return nil
+}
+
+// caseRejectAndFollow this case is intended to test that atomic groups are rejected safely
+// without side effects on the StateDB. To achieve that, the following txs will be sent:
+func caseRejectAndFollow(integration.IntegrationTest) error {
+	// TODO
+	return nil
+}

--- a/test/atomic/main.go
+++ b/test/atomic/main.go
@@ -10,6 +10,7 @@ Config requirements:
 
 import (
 	"math/big"
+	"sync"
 	"time"
 
 	integration "github.com/hermeznetwork/hermez-go-sdk/test"
@@ -28,11 +29,11 @@ func main() {
 	if len(it.Wallets) < 2 {
 		panic("To run this test at least two wallets with HEZ deposited must be provided.")
 	}
-	// Test happy path
-	if err := caseHappyPath(it); err != nil {
-		log.Error(err)
-		panic("Failed testing case: happy path")
-	}
+	// // Test happy path
+	// if err := caseHappyPath(it); err != nil {
+	// 	log.Error(err)
+	// 	panic("Failed testing case: happy path")
+	// }
 	// Test reject and follow
 	if err := caseRejectAndFollow(it); err != nil {
 		log.Error(err)
@@ -88,9 +89,6 @@ func caseHappyPath(it integration.IntegrationTest) error {
 		atomicGroup.Txs[i].Signature = signature.Compress()
 	}
 
-	// j, _ := json.Marshal(atomicGroup)
-	// panic(string(j))
-
 	// Post
 	var serverResponse string
 	serverResponse, err = transaction.SendAtomicTxsGroup(it.Client, atomicGroup)
@@ -98,10 +96,10 @@ func caseHappyPath(it integration.IntegrationTest) error {
 		return err
 	}
 	log.Info("Txs sent successfuly: ", serverResponse)
-	log.Info("You can manually check the status of the txs at: <node URL>/1/atomic-pool/")
+	log.Info("You can manually check the status of the txs at: " + it.Client.CurrentCoordinatorURL + "/v1/atomic-pool/" + atomicGroup.ID.String())
 	// Wait until txs are forged
 	log.Info("Entering a wait loop until txs are forged")
-	const timeBetweenChecks = 10 * time.Second
+	const timeBetweenChecks = 30 * time.Second
 	if err := integration.WaitUntilTxsAreForged(atomicGroup.Txs, timeBetweenChecks, it.Client); err != nil {
 		return err
 	}
@@ -111,7 +109,133 @@ func caseHappyPath(it integration.IntegrationTest) error {
 
 // caseRejectAndFollow this case is intended to test that atomic groups are rejected safely
 // without side effects on the StateDB. To achieve that, the following txs will be sent:
-func caseRejectAndFollow(integration.IntegrationTest) error {
-	// TODO
+func caseRejectAndFollow(it integration.IntegrationTest) error {
+	// 1. Send atomic group 1 with fee I and nonce X
+	// 2. Send atomic group 2 with fee J and nonce Y
+	// 3. Send atomic group 3 with fee K and nonce Z
+	// Force the txselector to reject groups by having (the lower the nonce the lower the fee):
+	// I < J < K
+	// X < Y < Z
+	// Each atomic group should be forged in different consecutive batches (due to current txselector implementation)
+	// TODO: check the batch num in which each batch is forged: should be sequentialy one per batch
+	log.Info("Start atomic test case: reject and follow")
+	log.Info("Sending 3 atomic groups of two linked txs that should be forged in 3 consecutive batches")
+	// Define txs
+	tx1 := transaction.AtomicTxItem{
+		SenderBjjWallet:       it.Wallets[0],
+		RecipientAddress:      it.Wallets[1].HezEthAddress,
+		TokenSymbolToTransfer: "HEZ",
+		Amount:                big.NewInt(100000000000000000),
+		FeeRangeSelectedID:    126,
+		RqOffSet:              1, //+1
+	}
+
+	tx2 := transaction.AtomicTxItem{
+		SenderBjjWallet:       it.Wallets[1],
+		RecipientAddress:      it.Wallets[0].HezEthAddress,
+		TokenSymbolToTransfer: "HEZ",
+		Amount:                big.NewInt(100000000000000000),
+		FeeRangeSelectedID:    126,
+		RqOffSet:              7, //-1
+	}
+	txs := make([]transaction.AtomicTxItem, 2)
+	txs[0] = tx1
+	txs[1] = tx2
+
+	// create PoolL2Txs
+	atomicGroup1 := common.AtomicGroup{}
+	atomicGroup2 := common.AtomicGroup{}
+	atomicGroup3 := common.AtomicGroup{}
+	fullTxs, err := transaction.CreateFullTxs(it.Client, txs)
+	if err != nil {
+		return err
+	}
+	atomicGroup1.Txs = make([]common.PoolL2Tx, 2)
+	copy(atomicGroup1.Txs, fullTxs)
+	atomicGroup2.Txs = make([]common.PoolL2Tx, 2)
+	copy(atomicGroup2.Txs, fullTxs)
+	atomicGroup3.Txs = make([]common.PoolL2Tx, 2)
+	copy(atomicGroup3.Txs, fullTxs)
+	// Manually modify fee and nonce for atomicGroup2 & atomicGroup3
+	for i := 0; i < len(fullTxs); i++ {
+		atomicGroup2.Txs[i].Fee += 1
+		atomicGroup2.Txs[i].Nonce += 1
+		atomicGroup2.Txs[i].RqFee += 1
+		atomicGroup2.Txs[i].RqNonce += 1
+		atomicGroup3.Txs[i].Fee += 2
+		atomicGroup3.Txs[i].Nonce += 2
+		atomicGroup3.Txs[i].RqFee += 2
+		atomicGroup3.Txs[i].RqNonce += 2
+	}
+
+	// Sign the txs for atomic group 1
+	for i := range txs {
+		var txHash *big.Int
+		txHash, err = atomicGroup1.Txs[i].HashToSign(uint16(5))
+		if err != nil {
+			return err
+		}
+		signature := txs[i].SenderBjjWallet.PrivateKey.SignPoseidon(txHash)
+		atomicGroup1.Txs[i].Signature = signature.Compress()
+	}
+	// Sign the txs for atomic group 2 and reset txID
+	for i := range txs {
+		atomicGroup2.Txs[i].TxID = common.EmptyTxID
+		if _, err := common.NewPoolL2Tx(&atomicGroup2.Txs[i]); err != nil {
+			return err
+		}
+		var txHash *big.Int
+		txHash, err = atomicGroup2.Txs[i].HashToSign(uint16(5))
+		if err != nil {
+			return err
+		}
+		signature := txs[i].SenderBjjWallet.PrivateKey.SignPoseidon(txHash)
+		atomicGroup2.Txs[i].Signature = signature.Compress()
+	}
+	// Sign the txs for atomic group 3 and reset txID
+	for i := range txs {
+		atomicGroup3.Txs[i].TxID = common.EmptyTxID
+		if _, err := common.NewPoolL2Tx(&atomicGroup3.Txs[i]); err != nil {
+			return err
+		}
+		var txHash *big.Int
+		txHash, err = atomicGroup3.Txs[i].HashToSign(uint16(5))
+		if err != nil {
+			return err
+		}
+		signature := txs[i].SenderBjjWallet.PrivateKey.SignPoseidon(txHash)
+		atomicGroup3.Txs[i].Signature = signature.Compress()
+	}
+	// set AtomicGroupID
+	atomicGroup1 = transaction.SetAtomicGroupID(atomicGroup1)
+	atomicGroup2 = transaction.SetAtomicGroupID(atomicGroup2)
+	atomicGroup3 = transaction.SetAtomicGroupID(atomicGroup3)
+
+	// Post
+	wg := new(sync.WaitGroup)
+	wg.Add(3)
+	const timeBetweenChecks = 30 * time.Second
+	waitForAtomicGroupToBeForged := func(ag common.AtomicGroup, agNum int) {
+		if err := integration.WaitUntilTxsAreForged(ag.Txs, timeBetweenChecks, it.Client); err != nil {
+			panic(err)
+		}
+		log.Info("Atomic group ", agNum, "has been forged, atomic group id: ", ag.ID.String())
+		wg.Done()
+	}
+	for i, ag := range []common.AtomicGroup{atomicGroup1, atomicGroup2, atomicGroup3} {
+		var serverResponse string
+		serverResponse, err = transaction.SendAtomicTxsGroup(it.Client, ag)
+		if err != nil {
+			return err
+		}
+		log.Info("Atomic group ", i+1, " sent successfuly: ", serverResponse)
+		log.Info("You can manually check the status of the txs at: " + it.Client.CurrentCoordinatorURL + "/v1/atomic-pool/" + ag.ID.String())
+		go waitForAtomicGroupToBeForged(ag, i+1)
+	}
+	// Wait until txs are forged
+	log.Info("Entering a wait loop until txs are forged")
+	wg.Wait()
+	log.Info("All transactions forged successfuly")
+
 	return nil
 }

--- a/test/config.example.toml
+++ b/test/config.example.toml
@@ -1,0 +1,3 @@
+AuctionAddress = "0x1D5c3Dd2003118743D596D7DB7EA07de6C90fB20" # Goerli
+EthNodeURL = "https://goerli.infura.io/v3/*******"
+EthPrivKeys = ["12aaD...", "444..."]

--- a/test/maxnumbatch/main.go
+++ b/test/maxnumbatch/main.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hermeznetwork/hermez-go-sdk/node"
+	integration "github.com/hermeznetwork/hermez-go-sdk/test"
+	"github.com/hermeznetwork/hermez-go-sdk/transaction"
+	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/log"
+)
+
+/*
+This integration test will perform transactions that include MaxNumBatch != 0.
+
+Config requirements:
+- One EthPrivKeys that have HEZ accounts with funds on Goerli
+- HermezNodeURL operating on Goerli, should win the auction too, oterwise the test will run forever
+- The coordinator should forge the tx within the next 30 batches from the moment the test is executed
+*/
+
+func main() {
+	// Load integration testing
+	it, err := integration.NewIntegrationTest()
+	if err != nil {
+		log.Error(err)
+		panic("Failed initializing integration testing framework")
+	}
+	if len(it.Wallets) == 0 {
+		panic("To run this test at least one wallet with HEZ deposited must be provided.")
+	}
+	// Test fail and success
+	if err := caseFailAndSuccess(it); err != nil {
+		log.Error(err)
+		panic("Failed testing case: fail and success")
+	}
+}
+
+// caseFailAndSuccess sends valid and invalid txs with MaxNumBatch != 0
+func caseFailAndSuccess(it integration.IntegrationTest) error {
+	/*
+	 TODO:
+	 -
+	*/
+	// Get current batch num
+	var currentBatchNum common.BatchNum
+	if state, err := node.GetBootCoordinatorNodeInfo(it.Client); err != nil {
+		return err
+	} else {
+		currentBatchNum = state.Network.LastBatch.BatchNum
+	}
+	// Get account details
+	idx, nonce, tokenId, err := transaction.GetAccountDetails(it.Client, it.Wallets[0].HezBjjAddress, "HEZ")
+	if err != nil {
+		return err
+	}
+	// Generate invalid tx because of MaxNumBatch
+	invalidTx := common.PoolL2Tx{
+		FromIdx:     idx,
+		ToIdx:       idx,
+		Nonce:       nonce,
+		Amount:      big.NewInt(100000000000000000),
+		TokenID:     tokenId,
+		TokenSymbol: "HEZ",
+		Fee:         170,
+		MaxNumBatch: uint32(currentBatchNum - 1),
+	}
+	if _, err := common.NewPoolL2Tx(&invalidTx); err != nil {
+		return err
+	}
+	if hash, err := invalidTx.HashToSign(5); err != nil {
+		return err
+	} else {
+		invalidTx.Signature = it.Wallets[0].PrivateKey.SignPoseidon(hash).Compress()
+	}
+	// Generate valid tx with MaxNumBatch != 0
+	validTx := common.PoolL2Tx{
+		FromIdx:     idx,
+		ToIdx:       idx,
+		Nonce:       nonce,
+		Amount:      big.NewInt(100000000000000000),
+		TokenID:     tokenId,
+		TokenSymbol: "HEZ",
+		Fee:         126,
+		MaxNumBatch: uint32(currentBatchNum + 30),
+	}
+	if _, err := common.NewPoolL2Tx(&validTx); err != nil {
+		return err
+	}
+	if hash, err := validTx.HashToSign(5); err != nil {
+		return err
+	} else {
+		validTx.Signature = it.Wallets[0].PrivateKey.SignPoseidon(hash).Compress()
+	}
+	// POST txs
+	for i, tx := range []common.PoolL2Tx{invalidTx, validTx} {
+		apiTxBody := new(bytes.Buffer)
+		if err := json.NewEncoder(apiTxBody).Encode(tx); err != nil {
+			return err
+		}
+
+		request, err := http.NewRequest(
+			"POST",
+			it.Client.CurrentCoordinatorURL+"/v1/transactions-pool",
+			apiTxBody,
+		)
+		if err != nil {
+			return err
+		}
+		response, err := it.Client.HttpClient.Do(request)
+		if err != nil {
+			return err
+		}
+
+		if response.StatusCode != 200 {
+			tempBuf, err := io.ReadAll(response.Body)
+			if err != nil {
+				response.Body.Close()
+				return err
+			}
+			response.Body.Close()
+			return errors.New(string(tempBuf))
+		} else {
+			checkMessage := fmt.Sprintf("You can manually check the status of the tx at %s/v1/transactions-pool/%s", it.Client.CurrentCoordinatorURL, tx.TxID.String())
+			if i == 0 {
+				log.Info("Invalid tx sent succesfully. ", checkMessage)
+			} else {
+				log.Info("Valid tx sent succesfully. ", checkMessage)
+			}
+		}
+	}
+
+	// Wait until valid tx is forged
+	log.Info("Entering a wait loop until txs are forged")
+	const timeBetweenChecks = 30 * time.Second
+	if err := integration.WaitUntilTxsAreForged([]common.PoolL2Tx{validTx}, timeBetweenChecks, it.Client); err != nil {
+		return err
+	}
+	log.Info("Valid tx is forged")
+
+	// Check Info of invalid tx
+	if tx, err := transaction.GetPoolL2Tx(it.Client, invalidTx.TxID); err != nil {
+		return err
+	} else if !strings.Contains(tx.Info, "MaxNumBatch exceeded") {
+		return fmt.Errorf("Unexpected rejection message, expected: MaxNumBatch exceeded. Actual %s", tx.Info)
+	}
+	return nil
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,100 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/hermeznetwork/hermez-go-sdk/account"
+	"github.com/hermeznetwork/hermez-go-sdk/client"
+	"github.com/hermeznetwork/hermez-go-sdk/transaction"
+	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/log"
+)
+
+const (
+	configPath = "./config.toml"
+)
+
+type config struct {
+	AuctionAddress string
+	EthNodeURL     string
+	HezNodeURL     string
+	EthPrivKeys    []string
+}
+
+type IntegrationTest struct {
+	Client  client.HermezClient
+	Wallets []account.BJJWallet
+}
+
+func NewIntegrationTest() (IntegrationTest, error) {
+	// Load config file
+	it := IntegrationTest{}
+	conf, err := loadConfig()
+	if err != nil {
+		return it, err
+	}
+	// Create SDK client
+	hezClient, err := client.NewHermezClient(conf.EthNodeURL, conf.AuctionAddress)
+	if err != nil {
+		return it, err
+	}
+	hezClient.BootCoordinatorURL = conf.HezNodeURL
+	hezClient.CurrentCoordinatorURL = conf.HezNodeURL
+	// Create wallets
+	wallets := []account.BJJWallet{}
+	for _, privK := range conf.EthPrivKeys {
+		w, _, err := account.CreateBjjWalletFromHexPvtKey(privK)
+		if err != nil {
+			return it, err
+		}
+		wallets = append(wallets, w)
+	}
+
+	return IntegrationTest{
+		Client:  hezClient,
+		Wallets: wallets,
+	}, nil
+}
+
+func loadConfig() (config, error) {
+	f, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return config{}, err
+	}
+	cfgToml := string(f)
+	c := config{}
+	_, err = toml.Decode(cfgToml, &c)
+	return c, err
+}
+
+func WaitUntilTxsAreForged(txs []common.PoolL2Tx, timeBetweenChecks time.Duration, hezClient client.HermezClient) error {
+	for {
+		// IsForged?
+		forgedTxs := 0
+		for _, tx := range txs {
+			_, err := transaction.GetL2Tx(hezClient, tx.TxID)
+			if err == nil {
+				forgedTxs += 1
+				continue
+			} else if err.Error() == "tx not forged" {
+				log.Info("txs not forged yet, waiting before retry")
+				time.Sleep(timeBetweenChecks)
+				break
+			} else {
+				return fmt.Errorf("Unexpected error: %e", err)
+			}
+		}
+		if forgedTxs == 0 {
+			// 0 txs forged, keep trying
+			continue
+		} else if forgedTxs == len(txs) {
+			// All txs forged, done
+			return nil
+		} else {
+			return fmt.Errorf("SOME txs forged (%d/%d)", forgedTxs, len(txs))
+		}
+	}
+}

--- a/transaction/atomic.go
+++ b/transaction/atomic.go
@@ -22,7 +22,7 @@ type AtomicTxItem struct {
 	RqOffSet              int
 }
 
-func getAccountDetails(hezClient client.HermezClient, address string,
+func GetAccountDetails(hezClient client.HermezClient, address string,
 	tokenToTransfer string) (idx hezCommon.Idx, nonce hezCommon.Nonce, tokenId hezCommon.TokenID, err error) {
 	var accDetails account.AccountAPIResponse
 	accDetails, err = account.GetAccountInfo(hezClient, address)
@@ -77,7 +77,7 @@ func CreateFullTxs(hezClient client.HermezClient, txs []AtomicTxItem) (fullTxs [
 		var idx hezCommon.Idx
 		var nonce hezCommon.Nonce
 		var tokenId hezCommon.TokenID
-		idx, nonce, tokenId, err = getAccountDetails(hezClient, txs[i].SenderBjjWallet.EthAccount.Address.Hex(), txs[i].TokenSymbolToTransfer)
+		idx, nonce, tokenId, err = GetAccountDetails(hezClient, txs[i].SenderBjjWallet.EthAccount.Address.Hex(), txs[i].TokenSymbolToTransfer)
 		if err != nil {
 			err = fmt.Errorf("[AtomicTransfer] Error obtaining sender account details. Account: %s - Error: %s\n", txs[i].SenderBjjWallet.EthAccount.Address.Hex(), err.Error())
 			return

--- a/transaction/http.go
+++ b/transaction/http.go
@@ -75,8 +75,8 @@ func SendAtomicTxsGroup(hezClient client.HermezClient, atomicTxs hezCommon.Atomi
 	log.Println("Bytes sent: ", apiTxBody)
 
 	var URL string
-	//URL = hezClient.CurrentCoordinatorURL + "/v1/atomic-pool"
-	URL = "https://marcelonode.xyz/v1/atomic-pool"
+	URL = hezClient.CurrentCoordinatorURL + "/v1/atomic-pool"
+	// URL = "https://marcelonode.xyz/v1/atomic-pool"
 	request, err := http.NewRequest("POST", URL, apiTxBody)
 	if err != nil {
 		err = fmt.Errorf("[SendAtomicTxsGroup] Error creating HTTP request. URL: %s - request: %+v - Error: %s\n", URL, apiTxBody, err.Error())
@@ -112,6 +112,6 @@ func SendAtomicTxsGroup(hezClient client.HermezClient, atomicTxs hezCommon.Atomi
 		return
 	}
 
-	serverResponse = fmt.Sprintln("Transaction ID submmited: ", atomicTxs.ID.String(), "Message returned in Hex: %s\n", common.Bytes2Hex(b))
+	serverResponse = fmt.Sprintln("Atomic Group ID submmited: ", atomicTxs.ID.String(), "Message returned in Hex: %s\n", common.Bytes2Hex(b))
 	return
 }

--- a/transaction/l2.go
+++ b/transaction/l2.go
@@ -110,3 +110,43 @@ func GetL2Tx(hezClient client.HermezClient, ID hezCommon.TxID) (hezCommon.PoolL2
 		return hezCommon.PoolL2Tx{}, errors.New("unexpected error")
 	}
 }
+
+func GetPoolL2Tx(hezClient client.HermezClient, ID hezCommon.TxID) (hezCommon.PoolL2Tx, error) {
+	URL := hezClient.BootCoordinatorURL + "/v1/transactions-pool/" + ID.String()
+	request, err := http.NewRequest("GET", URL, nil)
+	if err != nil {
+		err = fmt.Errorf("[GetL2Tx] Error creating HTTP request. URL: %s - Error: %s\n", URL, err.Error())
+		return hezCommon.PoolL2Tx{}, err
+	}
+	response, err := hezClient.HttpClient.Do(request)
+	if err != nil {
+		return hezCommon.PoolL2Tx{}, fmt.Errorf("[GetL2Tx] Error submitting HTTP request tx. URL: %s - request: %+v - Error: %s\n", URL, ID, err.Error())
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == 200 {
+		tempBuf, errResp := io.ReadAll(response.Body)
+		if errResp != nil {
+			err = fmt.Errorf("[GetL2Tx] Error unmarshaling tx: %s - Error: %s\n", ID, errResp.Error())
+			return hezCommon.PoolL2Tx{}, err
+		}
+		tx := hezCommon.PoolL2Tx{}
+		err = json.Unmarshal(tempBuf, &tx)
+		log.Info(string(tempBuf))
+		if err != nil {
+			err = fmt.Errorf("[GetL2Tx] Error unmarshaling tx: %s - Error: %s\n", ID, errResp.Error())
+			return hezCommon.PoolL2Tx{}, err
+		}
+		return tx, nil
+	} else if response.StatusCode == 404 {
+		tempBuf, errResp := io.ReadAll(response.Body)
+		if errResp != nil {
+			err = fmt.Errorf("[GetL2Tx] Error unmarshaling tx: %s - Error: %s\n", ID, errResp.Error())
+			return hezCommon.PoolL2Tx{}, err
+		}
+		log.Info(string(tempBuf))
+		return hezCommon.PoolL2Tx{}, errors.New("tx not forged")
+	} else {
+		return hezCommon.PoolL2Tx{}, errors.New("unexpected error")
+	}
+}


### PR DESCRIPTION
I was trying to use the SDK to perform atomic tests, since this is priority and I was having problems with the SDK, I moved the test to the SDK. However it's not clear to em where we should have those tests. My idea is to:

- Clean this PR to only include the fixes
- Move the tests to `red-team-tools` as a temporary solution until we decide how we handle tests

Note that this code is done with testing the atomic txs ASAP, therefore it's a draft, I'm creating this PR to show the problems I've found to the team

Also keep in mind that some changes that I've done suit my use case, but they're not generic so shouldn't be included, in particular I've adapted the function `func CreateFullTxs(hezClient client.HermezClient, txs []AtomicTxItem) (fullTxs []hezCommon.PoolL2Tx, err error)` to perform transfers of type to Ethereum address